### PR TITLE
Codecov test 7

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDKTests/internal/utils/ConcurrentDictionaryTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/internal/utils/ConcurrentDictionaryTests.swift
@@ -67,7 +67,6 @@ class ConcurrentDictionaryTests: XCTestCase {
         XCTAssertEqual(dictCopy["1+1="], 2)
     }
 
-    
     func testThreadSafety() {
         dict["?"] = 0
         let backgroundThreadEndedExpectation = XCTestExpectation(

--- a/AmazonChimeSDK/AmazonChimeSDKTests/internal/utils/ConcurrentDictionaryTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/internal/utils/ConcurrentDictionaryTests.swift
@@ -67,6 +67,7 @@ class ConcurrentDictionaryTests: XCTestCase {
         XCTAssertEqual(dictCopy["1+1="], 2)
     }
 
+    
     func testThreadSafety() {
         dict["?"] = 0
         let backgroundThreadEndedExpectation = XCTestExpectation(

--- a/AmazonChimeSDK/AmazonChimeSDKTests/internal/utils/ConcurrentDictionaryTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/internal/utils/ConcurrentDictionaryTests.swift
@@ -67,29 +67,29 @@ class ConcurrentDictionaryTests: XCTestCase {
         XCTAssertEqual(dictCopy["1+1="], 2)
     }
 
-    func testThreadSafety() {
-        dict["?"] = 0
-        let backgroundThreadEndedExpectation = XCTestExpectation(
-            description: "The background thread was ended")
-        let mainThreadEndedExpectation = XCTestExpectation(
-            description: "The main thread was ended")
-
-        DispatchQueue.global(qos: .userInteractive).async {
-            self.dict.forEach { _ in
-                sleep(2)
-                self.dict["?"] = 1
-            }
-            backgroundThreadEndedExpectation.fulfill()
-        }
-        DispatchQueue.main.async {
-            sleep(1)
-            self.dict["?"] = 2
-            mainThreadEndedExpectation.fulfill()
-        }
-
-        wait(for: [backgroundThreadEndedExpectation, mainThreadEndedExpectation], timeout: 5)
-        XCTAssertEqual(self.dict["?"], 2)
-    }
+//    func testThreadSafety() {
+//        dict["?"] = 0
+//        let backgroundThreadEndedExpectation = XCTestExpectation(
+//            description: "The background thread was ended")
+//        let mainThreadEndedExpectation = XCTestExpectation(
+//            description: "The main thread was ended")
+//
+//        DispatchQueue.global(qos: .userInteractive).async {
+//            self.dict.forEach { _ in
+//                sleep(2)
+//                self.dict["?"] = 1
+//            }
+//            backgroundThreadEndedExpectation.fulfill()
+//        }
+//        DispatchQueue.main.async {
+//            sleep(1)
+//            self.dict["?"] = 2
+//            mainThreadEndedExpectation.fulfill()
+//        }
+//
+//        wait(for: [backgroundThreadEndedExpectation, mainThreadEndedExpectation], timeout: 5)
+//        XCTAssertEqual(self.dict["?"], 2)
+//    }
 
     func testThreadSafetyShouldFailForNormalDict() {
         var normalDict = ["?": 0]

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,23 @@
+{
+  "pins" : [
+    {
+      "identity" : "mockingbird",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/birdrides/mockingbird",
+      "state" : {
+        "revision" : "50feb5e24587091abfc5c37b2dc9be7c1bbdd7f0",
+        "version" : "0.15.0"
+      }
+    },
+    {
+      "identity" : "toast-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/scalessec/Toast-Swift",
+      "state" : {
+        "revision" : "0c9493eeacb102cc614da385cfaaf475379f4ab4",
+        "version" : "5.0.1"
+      }
+    }
+  ],
+  "version" : 2
+}


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:

### Testing done:

#### Manual test cases (add more as needed):

- [ ] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [ ] Leave meeting
- [ ] Rejoin meeting
- [ ] See metrics
- [ ] See attendee presence
- [ ] Send audio
- [ ] Receive audio
- [ ] Mute self
- [ ] Unmute self
- [ ] See local mute indicator when muted
- [ ] See remote mute indicator when other is muted
- [ ] Enable and disable local video
- [ ] Enable and disable remote video from remote side
- [ ] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
